### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $(function () {
 
 This anti-pattern leads to many issues, which rsjs attempts to address.
 
- * **Ambiguious sources:** It's not obvious where to look for the JS behavior. (Is the handler attached to *.author*, *.footnote*, or *.profile-link*?)
+ * **Ambiguous sources:** It's not obvious where to look for the JS behavior. (Is the handler attached to *.author*, *.footnote*, or *.profile-link*?)
 
  * **Non-reusable:** It's not obvious how to reuse the behavior in another page. (Should *blogpost.js* be included in the other pages that need it? What if that file contains other behaviors you don't need for that page?)
 


### PR DESCRIPTION
This will fix a simple typo in README.md

**Ambiguious** -> **Ambiguous**